### PR TITLE
bump org.seleniumhq.selenium:selenium-java from 4.13.0 to 4.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 	</properties>
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.13.0</version>
+			<version>4.32.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.microsoft.playwright</groupId>


### PR DESCRIPTION
fix breaking changes caused by Dependabot automatic upgrade of dependencies

Changes:
1. change jdk version from 1.8 to 11
2. bump org.seleniumhq.selenium:selenium-java from 4.13.0 to 4.32.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Javaバージョンを1.8から11に更新しました。
  - Selenium Javaの依存バージョンを4.13.0から4.32.0にアップグレードしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->